### PR TITLE
Simulate keypresses on kill

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,11 @@ THREE_KILLS_AUDIO=C:\Path\To\Your\Sounds_3.wav
 #Doesn't have to be set, but if it's set it'll play a random audio file from this folder - instead of ONE_KILL_AUDIO
 RANDOM_AUDIO_FOLDER=C:\Path\To\Your\RandomSoundCollection
 
+ONE_KILL_KEYSTROKE=
+TWO_KILLS_KEYSTROKE=
+THREE_KILLS_KEYSTROKE=ctrl+alt+i
+KEYSTROKE_DELAY=1
+
 AUTOREFRESH_WINDOW_POSITION=True
 
 DEBUG_SAVE_DETECTED_TEXT_IMAGES=True

--- a/README.md
+++ b/README.md
@@ -18,19 +18,23 @@ The game window has to be open and visible on the desktop! Make it as large as p
 
 Explanation of the variables in `.env`:
 
-| Variable                       | Description                                                                                        |
-|--------------------------------|----------------------------------------------------------------------------------------------------|
-| `INGAME_USERNAME`              | Your in-game username                                                                              |
-| `WINDOW_NAME`                  | Name of game window. The window has to be in the front and un-minimized. Usually `Population: ONE` |
-| `TESSERACT_PATH`               | Path to your install of tesseract, probably `C:\Program Files\Tesseract-OCR\tesseract.exe`         |
-| `TIME_INTERVAL_SECONDS`        | Time in seconds between individual screen reads. Set this to `1` or `2`                            |
-| `FORCE_WINDOW_FRONT`           | Force window to be on top before every cycle - Set to `True`/`False`                               |
-| `MULTI_KILL_TIMEFRAME_SECONDS` | How long do kills stack? In seconds - `15` to `20` seconds seems nice                              |
-| `ONE_KILL_AUDIO`               | Path to your audio file for doing one kill                                                         |
-| `TWO_KILLS_AUDIO`              | Path to your audio file for doing two kills                                                        |
-| `THREE_KILLS_AUDIO`            | Path to your audio file for doing three kills                                                      |
-| `RANDOM_AUDIO_FOLDER`          | Optional - play a random file from this folder instead of `ONE_KILL_AUDIO`                         |
-| `AUTOREFRESH_WINDOW_POSITION`  | Recalculate window position before each cycle - Set to `True`/`False`                              |
+| Variable                       | Description                                                                                          |
+|--------------------------------|------------------------------------------------------------------------------------------------------|
+| `INGAME_USERNAME`              | Your in-game username                                                                                |
+| `WINDOW_NAME`                  | Name of game window. The window has to be in the front and un-minimized. Usually `Population: ONE`   |
+| `TESSERACT_PATH`               | Path to your install of tesseract, probably `C:\Program Files\Tesseract-OCR\tesseract.exe`           |
+| `TIME_INTERVAL_SECONDS`        | Time in seconds between individual screen reads. Set this to `1` or `2`                              |
+| `FORCE_WINDOW_FRONT`           | Force window to be on top before every cycle - Set to `True`/`False`                                 |
+| `MULTI_KILL_TIMEFRAME_SECONDS` | How long do kills stack? In seconds - `15` to `20` seconds seems nice                                |
+| `ONE_KILL_AUDIO`               | Path to your audio file for doing one kill                                                           |
+| `TWO_KILLS_AUDIO`              | Path to your audio file for doing two kills                                                          |
+| `THREE_KILLS_AUDIO`            | Path to your audio file for doing three kills                                                        |
+| `RANDOM_AUDIO_FOLDER`          | Optional - play a random file from this folder instead of `ONE_KILL_AUDIO`                           |
+| `ONE_KILL_KEYSTROKE`           | Keys to press for doing one kill. Single key (`tab`), combo (`alt+f4`), or series (`ctrl+c, ctrl+v`) |
+| `TWO_KILLS_KEYSTROKE`          | Keys to press for doing two kills                                                                    |
+| `THREE_KILLS_KEYSTROKE`        | Keys to press for doing three kills                                                                  |
+| `KEYSTROKE_DELAY`              | Time in seconds to delay a keypress after a kill. Set this to `0` to press immediately               |
+| `AUTOREFRESH_WINDOW_POSITION`  | Recalculate window position before each cycle - Set to `True`/`False`                                |
 
 # How to run
 You can simply grab the binary executable from the [releases page](https://github.com/lacksfish/popOne-kill-alerts/releases).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+keyboard==0.13.5
 mss==6.1.0
 numpy==1.21.0
 opencv-python==4.5.2.54

--- a/src/main.py
+++ b/src/main.py
@@ -11,6 +11,7 @@ import logging
 from logging.handlers import RotatingFileHandler
 import pytesseract
 from pygame import mixer
+import keyboard
 
 from lib.img import ScreenShooter
 from lib.utils import maxDiff, jaro_winkler, gun_names
@@ -39,6 +40,9 @@ ONE_KILL_AUDIO = os.getenv('ONE_KILL_AUDIO')
 TWO_KILLS_AUDIO = os.getenv('TWO_KILLS_AUDIO')
 THREE_KILLS_AUDIO = os.getenv('THREE_KILLS_AUDIO')
 RANDOM_AUDIO_FOLDER = os.getenv('RANDOM_AUDIO_FOLDER')
+ONE_KILL_KEYSTROKE = os.getenv('ONE_KILL_KEYSTROKE')
+TWO_KILLS_KEYSTROKE = os.getenv('TWO_KILLS_KEYSTROKE')
+THREE_KILLS_KEYSTROKE = os.getenv('THREE_KILLS_KEYSTROKE')
 
 DEBUG_SAVE_DETECTED_TEXT_IMAGES = os.getenv("DEBUG_SAVE_DETECTED_TEXT_IMAGES", 'False').lower() in ('true', '1', 't')
 
@@ -180,9 +184,13 @@ try:
                         if len(kill_ts_list) > 2 and maxDiff(timestamps[-3:]) <= MULTI_KILL_TIMEDELTA_SECONDS:
                             if THREE_KILLS_AUDIO is not None:
                                 play_audio(THREE_KILLS_AUDIO)
+                            if THREE_KILLS_KEYSTROKE is not None:
+                                keyboard.press_and_release(THREE_KILLS_KEYSTROKE)
                         elif len(kill_ts_list) > 1 and maxDiff(timestamps[-2:]) <= MULTI_KILL_TIMEDELTA_SECONDS:
                             if TWO_KILLS_AUDIO is not None:
                                 play_audio(TWO_KILLS_AUDIO)
+                            if TWO_KILLS_KEYSTROKE is not None:
+                                keyboard.press_and_release(TWO_KILLS_KEYSTROKE)
                         else:
                             if os.path.isdir(RANDOM_AUDIO_FOLDER if RANDOM_AUDIO_FOLDER is not None else ''):
                                 audio = random.choice([x for x in os.listdir(RANDOM_AUDIO_FOLDER) if os.path.isfile(os.path.join(RANDOM_AUDIO_FOLDER, x))])
@@ -190,6 +198,8 @@ try:
                             else:
                                 if ONE_KILL_AUDIO is not None:
                                     play_audio(ONE_KILL_AUDIO)
+                                if ONE_KILL_KEYSTROKE is not None:
+                                    keyboard.press_and_release(ONE_KILL_KEYSTROKE)
 
         end_ts = time.time()
         last_read_delay = end_ts - start_ts

--- a/src/main.py
+++ b/src/main.py
@@ -77,6 +77,7 @@ try:
     # kill_ts_list = [{'time': time.time(), 'name': 'BobbyBoyy'}]
     DEBUG_detected_list = []
 
+    keystroke_queue_key = None
     keystroke_queue_time = None
 
     logger.info('(x) Everything looks good, initialized. Running ...\n')
@@ -197,19 +198,23 @@ try:
                                 keystroke_queue_time = time.time()
                                 keystroke_queue_key = TWO_KILLS_KEYSTROKE
                         else:
-                            if os.path.isdir(RANDOM_AUDIO_FOLDER if RANDOM_AUDIO_FOLDER is not None else ''):
+                            if os.path.isdir(RANDOM_AUDIO_FOLDER if RANDOM_AUDIO_FOLDER is not None else False):
                                 audio = random.choice([x for x in os.listdir(RANDOM_AUDIO_FOLDER) if os.path.isfile(os.path.join(RANDOM_AUDIO_FOLDER, x))])
                                 play_audio(os.path.join(RANDOM_AUDIO_FOLDER, audio))
                             else:
                                 if ONE_KILL_AUDIO is not None:
                                     play_audio(ONE_KILL_AUDIO)
-                                if ONE_KILL_KEYSTROKE is not None:
-                                    keystroke_queue_time = time.time()
-                                    keystroke_queue_key = ONE_KILL_KEYSTROKE
+
+                            if ONE_KILL_KEYSTROKE is not None:
+                                keystroke_queue_time = time.time()
+                                keystroke_queue_key = ONE_KILL_KEYSTROKE
 
         if keystroke_queue_time is not None and time.time() - keystroke_queue_time >= KEYSTROKE_DELAY:
             # Perform the queued keystroke
-            keyboard.press_and_release(keystroke_queue_key)
+            keyboard.press(keystroke_queue_key)
+            time.sleep(0.05)
+            keyboard.release(keystroke_queue_key)
+            keystroke_queue_key = None
             keystroke_queue_time = None
 
         end_ts = time.time()

--- a/src/main.py
+++ b/src/main.py
@@ -35,6 +35,9 @@ TIME_INTERVAL_SECONDS = os.getenv('TIME_INTERVAL_SECONDS')
 MULTI_KILL_TIMEDELTA_SECONDS = int(os.getenv('MULTI_KILL_TIMEFRAME_SECONDS'))
 FORCE_WINDOW_FRONT = os.getenv("FORCE_WINDOW_FRONT", 'False').lower() in ('true', '1', 't')
 AUTOREFRESH_WINDOW_POSITION = os.getenv("AUTOREFRESH_WINDOW_POSITION", 'False').lower() in ('true', '1', 't')
+ONE_KILL_AUDIO = os.getenv('ONE_KILL_AUDIO')
+TWO_KILLS_AUDIO = os.getenv('TWO_KILLS_AUDIO')
+THREE_KILLS_AUDIO = os.getenv('THREE_KILLS_AUDIO')
 RANDOM_AUDIO_FOLDER = os.getenv('RANDOM_AUDIO_FOLDER')
 
 DEBUG_SAVE_DETECTED_TEXT_IMAGES = os.getenv("DEBUG_SAVE_DETECTED_TEXT_IMAGES", 'False').lower() in ('true', '1', 't')
@@ -175,15 +178,18 @@ try:
                         timestamps = [x['time'] for x in kill_ts_list]
 
                         if len(kill_ts_list) > 2 and maxDiff(timestamps[-3:]) <= MULTI_KILL_TIMEDELTA_SECONDS:
-                            play_audio(os.getenv('THREE_KILLS_AUDIO'))
+                            if THREE_KILLS_AUDIO is not None:
+                                play_audio(THREE_KILLS_AUDIO)
                         elif len(kill_ts_list) > 1 and maxDiff(timestamps[-2:]) <= MULTI_KILL_TIMEDELTA_SECONDS:
-                            play_audio(os.getenv('TWO_KILLS_AUDIO'))
+                            if TWO_KILLS_AUDIO is not None:
+                                play_audio(TWO_KILLS_AUDIO)
                         else:
                             if os.path.isdir(RANDOM_AUDIO_FOLDER if RANDOM_AUDIO_FOLDER is not None else ''):
                                 audio = random.choice([x for x in os.listdir(RANDOM_AUDIO_FOLDER) if os.path.isfile(os.path.join(RANDOM_AUDIO_FOLDER, x))])
                                 play_audio(os.path.join(RANDOM_AUDIO_FOLDER, audio))
                             else:
-                                play_audio(os.getenv('ONE_KILL_AUDIO'))
+                                if ONE_KILL_AUDIO is not None:
+                                    play_audio(ONE_KILL_AUDIO)
 
         end_ts = time.time()
         last_read_delay = end_ts - start_ts


### PR DESCRIPTION
Added the ability to define some key combos to be pressed after a kill. This is useful for capturing screenshots and video, or potentially communicating with outside software to modify a user's stream or gameplay.

I've used the `keyboard` module on PyPI to simulated keypresses (https://github.com/boppreh/keyboard). This module has the handy feature of allowing users to define key combos as strings, like `alt+f4`. The key combos can be custom defined in a user's `.env` file.

Closes issue #2 